### PR TITLE
Remove deprecated pip parameter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ python:
   - "3.3"
 # command to install dependencies
 install:
-  - "pip install . --use-mirrors"
-  - "pip install -r requirements.txt --use-mirrors"
+  - "pip install ."
+  - "pip install -r requirements.txt"
 # command to run tests
 script: 
   - python mtq/tests/runtests.py


### PR DESCRIPTION
According to [pip documentation](https://pip.pypa.io/en/stable/news/)  `pip install --use-mirrors` was deprecated and completely removed in v7.0.0.