### PR TITLE
Update travisCI configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+
+# start services
+services:
+  - mongodb
+
 # command to install dependencies
 install:
   - "pip install ."

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,18 @@
 language: python
 python:
   - "2.7"
-  - "3.2"
   - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.6"
 # command to install dependencies
 install:
   - "pip install ."
   - "pip install -r requirements.txt"
 # command to run tests
-script: 
+script:
   - python mtq/tests/runtests.py
-  
+
 after_success:
   - pip install coveralls
   - coveralls
-
-

--- a/mtq/connection.py
+++ b/mtq/connection.py
@@ -81,8 +81,7 @@ class MTQConnection(object):
         job = self.get_job(job_id)
         return job.stream()
 
-    def worker_stream(self, worker_name=None,
-                            worker_id=None):
+    def worker_stream(self, worker_name=None, worker_id=None):
         '''
         Get a file like object for the output of a worker
         '''
@@ -150,7 +149,6 @@ class MTQConnection(object):
 
         return tag_query
 
-
     def add_mutex(self, query):
         running_query = self.make_query(None, None, processed=True)
         cursor = find(running_query, projection={'mutex':1, '_id':0},
@@ -172,7 +170,8 @@ class MTQConnection(object):
             mutex[mutext_key] += 1
 
         # Query should inclue jobs with no mutex key or where its key is not in any running jobs
-        _or = [{'mutex': None}, {'mutex': {'$exists': False}}, {'mutex.key': {'$nin': mutex.keys()}}]
+        _or = [{'mutex': None}, {'mutex': {'$exists': False}},
+               {'mutex.key': {'$nin': list(mutex.keys())}}]
 
         # Query should inclue jobs where the mutex.count is > the # already running
         for key, already_running in mutex.items():
@@ -230,8 +229,6 @@ class MTQConnection(object):
 
         return mtq.Queue(self, name, tags, priority)
 
-
-
     def new_worker(self, queues=(), tags=(), priority=0, silence=False,
                    log_worker_output=False, poll_interval=3, args=None):
         '''
@@ -250,9 +247,9 @@ class MTQConnection(object):
         self.worker = worker
         return worker
 
-    #===========================================================================
+    # ===========================================================================
     # Workers
-    #===========================================================================
+    # ===========================================================================
     @property
     def worker_collection(self):
         'Collection to register workers to'
@@ -275,7 +272,6 @@ class MTQConnection(object):
         '''
         collection = self.worker_collection
         return [mtq.WorkerProxy(self, item) for item in collection.find({'working':True})]
-
 
     def get_job(self, job_id):
         '''
@@ -305,12 +301,9 @@ class MTQConnection(object):
 
         return mtq.WorkerProxy(self, doc)
 
-
-    #===========================================================================
+    # ===========================================================================
     # Scheduler
-    #===========================================================================
+    # ===========================================================================
 
     def scheduler(self):
         return mtq.Scheduler(self)
-
-

--- a/mtq/tests/runtests.py
+++ b/mtq/tests/runtests.py
@@ -4,8 +4,11 @@ Created on Aug 5, 2013
 @author: sean
 '''
 from __future__ import print_function
-import unittest
 from os.path import dirname
+
+import sys
+import unittest
+
 
 def main():
     import coverage
@@ -16,10 +19,14 @@ def main():
     loader = unittest.loader.TestLoader()
     tests = loader.discover(dirname(__file__))
     runner = unittest.TextTestRunner()
-    runner.run(tests) 
+    result = runner.run(tests)
     cov.stop()
     cov.save()
     cov.report()
+
+    # Exit code depends on tests result
+    import ipdb; ipdb.set_trace()
+    sys.exit(0 if result.wasSuccessful() else -1)
 
 if __name__ == '__main__':
     main()

--- a/mtq/tests/runtests.py
+++ b/mtq/tests/runtests.py
@@ -25,7 +25,6 @@ def main():
     cov.report()
 
     # Exit code depends on tests result
-    import ipdb; ipdb.set_trace()
     sys.exit(0 if result.wasSuccessful() else -1)
 
 if __name__ == '__main__':

--- a/mtq/tests/test_queue.py
+++ b/mtq/tests/test_queue.py
@@ -8,7 +8,7 @@ import mtq.tests.fixture
 from mtq.utils import now
 import unittest
 from mtq.queue import QueueError
-import time
+
 
 class TestQueue(MTQTestCase):
 
@@ -48,13 +48,10 @@ class TestQueue(MTQTestCase):
         with self.assertRaises(TypeError):
             q.enqueue_call('fine', kwargs='str')
 
-
     def test_enqueue(self):
         'Creating queues.'
         q = self.factory.queue('my-queue', ['tags'])
-
         q.enqueue('call-me')
-
 
     def test_jobs(self):
         'Creating queues.'
@@ -74,10 +71,10 @@ class TestQueue(MTQTestCase):
         q = self.factory.queue('example')
         self.assertEqual(q.is_empty(), True)
 
-        self.factory.queue_collection.insert({'qname':'example',
+        self.factory.queue_collection.insert({'qname': 'example',
                                               'process_after': now(),
                                               'priority': 0,
-                                              'processed':False
+                                              'processed': False
                                               })
         self.assertEqual(q.is_empty(), False)
 
@@ -86,12 +83,8 @@ class TestQueue(MTQTestCase):
         q = self.factory.queue('my-queue')
         q.enqueue_call('call-me', tags=['1', '2'])
         q.enqueue_call('call-me', tags=['2', '3'])
-
         self.assertEqual(q.count, 2)
-
         self.assertEqual(q.all_tags, set(['1', '2', '3']))
-
-
 
     def test_pop(self):
         q = self.factory.queue('my-queue')
@@ -142,7 +135,6 @@ class TestQueue(MTQTestCase):
         self.assertIsNotNone(job2)
         self.assertIsNotNone(job3)
         self.assertIsNone(job4)
-
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR includes:
- Remove support for Python 3.2 and add support for 3.4, 3.5, 3.6. (According to [setuptools changelog](http://setuptools.readthedocs.io/en/latest/history.html#v30-0-0) support for Python 3.2 was dropped.)
- Define mongodb as a requirement in travis.yml (all tests were silently failing!)
- Improve runtests.py to return a proper exit code (It was returning '0' always!!!)
- As a side effect coverage percentage was increased by ~34%
- Fix compatibility issue with Python 3